### PR TITLE
(SIMP-1450) Update to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
+- Updated to use the version of 'simpcat' that does not conflict with
+  'puppetlabs/concat'.
+
 * Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 3.0.0-3
 - migration to simplib and simpcat (lib/ only)
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,4 +1,4 @@
 Requires: pupmod-simp-auditd >= 2.0.0-0
 Requires: pupmod-simp-rsyslog >= 2.0.0-0
-Requires: pupmod-simp-simpcat >= 2.0.0-0
+Requires: pupmod-simp-simpcat >= 6.0.0-0
 Obsoletes: pupmod-tcpwrappers-test >= 0.0.1

--- a/manifests/allow.pp
+++ b/manifests/allow.pp
@@ -24,7 +24,7 @@ define tcpwrappers::allow (
 
     $l_name = inline_template('<%= @name.gsub(/\s+/,"_") %>')
 
-    concat_fragment { "tcpwrappers+${order}.${l_name}.allow":
+    simpcat_fragment { "tcpwrappers+${order}.${l_name}.allow":
       content => template('tcpwrappers/tcpwrappers.allow.erb')
     }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@
 #
 class tcpwrappers {
 
-    concat_build { 'tcpwrappers':
+    simpcat_build { 'tcpwrappers':
       order   => ['*.allow'],
       target  => '/etc/hosts.allow',
       require => Package['tcp_wrappers']
@@ -22,7 +22,7 @@ class tcpwrappers {
       mode      => '0644',
       require   => Package['tcp_wrappers'],
       audit     => content,
-      subscribe => Concat_build['tcpwrappers']
+      subscribe => Simpcat_build['tcpwrappers']
     }
 
     # Deny everything by default.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-tcpwrappers",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "author":  "simp",
   "summary": "manages /etc/hosts.allow (/etc/hosts.deny is ALL:ALL by default)",
   "license": "Apache-2.0",
@@ -15,7 +15,7 @@
     },
     {
       "name": "simp-simpcat",
-      "version_requirement": ">= 2.0.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp-rsyslog",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,7 +13,7 @@ describe 'tcpwrappers' do
         })}
 
         it do
-          is_expected.to contain_concat_build('tcpwrappers').with({
+          is_expected.to contain_simpcat_build('tcpwrappers').with({
             'order' => ['*.allow'],
             'target' => '/etc/hosts.allow',
             'require' => 'Package[tcp_wrappers]'
@@ -27,7 +27,7 @@ describe 'tcpwrappers' do
             'mode'  => '0644',
             'require' => 'Package[tcp_wrappers]',
             'audit' => 'content',
-            'subscribe' => 'Concat_build[tcpwrappers]'
+            'subscribe' => 'Simpcat_build[tcpwrappers]'
           })
         end
 

--- a/spec/defines/allow_spec.rb
+++ b/spec/defines/allow_spec.rb
@@ -6,7 +6,7 @@ describe 'tcpwrappers::allow' do
       context "on #{os}" do
         let(:title) { 'foo_bar' }
         let(:params) { {:pattern => 'localhost'} }
-        it { is_expected.to contain_concat_fragment('tcpwrappers+1000.foo_bar.allow') }
+        it { is_expected.to contain_simpcat_fragment('tcpwrappers+1000.foo_bar.allow') }
       end
     end
   end


### PR DESCRIPTION
Updated to use the version of 'simpcat' that does not conflict with
'puppetlabs/concat'.

SIMP-1450 #comment Update to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted 'tcpwrappers'
