### PR TITLE
(SIMP-3613) tcpwrappers: Update to concat 3.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Aug 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.2-0
+- Update concat version in metadata.json & build/rpm_metadata/requires
+
 * Thu Jul 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.1-0
 - Update puppet dependency and remove OBE pe dependency in metadata.json
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -3,6 +3,6 @@ Requires: pupmod-simp-simplib < 4.0.0-0
 Requires: pupmod-simp-simplib >= 3.1.0-0
 Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
 Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0
-Requires: pupmod-puppetlabs-concat < 3.0.0-0
+Requires: pupmod-puppetlabs-concat < 4.0.0-0
 Requires: pupmod-puppetlabs-concat >= 2.2.0-0
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-tcpwrappers",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "author": "SIMP Team",
   "summary": "manages /etc/hosts.allow (/etc/hosts.deny is ALL:ALL by default)",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
+      "version_requirement": ">= 2.2.0 < 4.0.0"
     },
     {
       "name": "simp-simplib",


### PR DESCRIPTION
concat 3.0.0 is fully backward compatible with 2.x.