### PR TITLE
(SIMP-3613) tcpwrappers: Pin concat to 3.0.0 in .fixtures.yml

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,7 @@ fixtures:
   repositories:
     concat:
       repo: "https://github.com/simp/puppetlabs-concat"
-      branch: 'simp-master'
+      ref: 3.0.0
     simplib: "https://github.com/simp/pupmod-simp-simplib"
     stdlib:
       repo: "https://github.com/simp/puppetlabs-stdlib"


### PR DESCRIPTION
Pin concat to 3.0.0 in .fixtures.yml, as metadata.json bounds
concat to < 4.0.0.