### PR TITLE
(SIMP-6111) Use (namespaced) simplib::ipaddresses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Feb 14 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.1-0
+- Use simplib::ipaddresses() in lieu of ipaddresses(), a deprecated
+  simplib Puppet 3 function.
+
 * Fri Aug 24 2018 Nick Miller <nick.miller@onypoint.com> - 6.1.0-0
 - Add support for Puppet 5 and OEL
 - Added $package_ensure parameter

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@ class tcpwrappers (
       'LOCAL',
       $facts['fqdn'],
       'localhost.localdomain',
-      join(ipaddresses(),',')
+      join(simplib::ipaddresses(),',')
     ]
 
     tcpwrappers::allow { 'ALL':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-tcpwrappers",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "author": "SIMP Team",
   "summary": "manages /etc/hosts.allow (/etc/hosts.deny is ALL:ALL by default)",
   "license": "Apache-2.0",
@@ -22,7 +22,7 @@
     },
     {
       "name": "simp-simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.5.0 < 4.0.0"
     }
   ],
   "requirements": [

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,16 +2,11 @@ require 'spec_helper'
 
 describe 'tcpwrappers' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
+        let (:facts) { os_facts }
+
         it { is_expected.to create_class('tcpwrappers') }
-
-        let (:facts) { facts.merge({
-          :fqdn         => 'foo.bar.baz',
-          :interfaces   => 'lo',
-          :ipaddress_lo => '127.0.0.1'
-        })}
-
         it { is_expected.to contain_package('tcp_wrappers') }
 
         it do
@@ -32,7 +27,7 @@ describe 'tcpwrappers' do
 
         it do
           is_expected.to contain_tcpwrappers__allow('ALL').with({
-            'pattern' => 'LOCAL,foo.bar.baz,localhost.localdomain,127.0.0.1',
+            'pattern' => 'LOCAL,foo.example.com,localhost.localdomain,10.0.2.15,127.0.0.1',
             'order'   => 0
           })
         end


### PR DESCRIPTION
Use simplib::ipaddresses() in lieu of ipaddresses(), a deprecated
simplib Puppet 3 function.

SIMP-6111 #close