### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,11 +1,7 @@
 ---
 fixtures:
   repositories:
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
   symlinks:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 * Thu Feb 14 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.1-0
 - Use simplib::ipaddresses() in lieu of ipaddresses(), a deprecated
   simplib Puppet 3 function.
+- Expanded the upper limit of the concat and stdlib Puppet module versions
+- Fixed URLs in the README.md
 
 * Fri Aug 24 2018 Nick Miller <nick.miller@onypoint.com> - 6.1.0-0
 - Add support for Puppet 5 and OEL

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html) [![Build Status](https://travis-ci.org/simp/pupmod-simp-tcpwrappers.svg)](https://travis-ci.org/simp/pupmod-simp-tcpwrappers) [![SIMP compatibility](https://img.shields.io/badge/SIMP%20compatibility-4.2.*%2F5.1.*-orange.svg)](https://img.shields.io/badge/SIMP%20compatibility-4.2.*%2F5.1.*-orange.svg)
+[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/73/badge)](https://bestpractices.coreinfrastructure.org/projects/73)
+[![Puppet Forge](https://img.shields.io/puppetforge/v/simp/tcpwrappers.svg)](https://forge.puppetlabs.com/simp/tcpwrappers)
+[![Puppet Forge Downloads](https://img.shields.io/puppetforge/dt/simp/tcpwrappers.svg)](https://forge.puppetlabs.com/simp/tcpwrappers)
+[![Build Status](https://travis-ci.org/simp/pupmod-simp-tcpwrappers.svg)](https://travis-ci.org/simp/pupmod-simp-tcpwrappers)
 
 ## This is a SIMP module
-This module is a component of the [System Integrity Management Platform](https://github.com/NationalSecurityAgency/SIMP), a compliance-management framework built on Puppet.
+
+This module is a component of the [System Integrity Management Platform](https://simp-project.com),
+a compliance-management framework built on Puppet.
 
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net/).
 
-Please read our [Contribution Guide](https://simp-project.atlassian.net/wiki/display/SD/Contributing+to+SIMP) and visit our [developer wiki](https://simp-project.atlassian.net/wiki/display/SD/SIMP+Development+Home).
+Please read our [Contribution Guide] (https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ## Work in Progress
 

--- a/metadata.json
+++ b/metadata.json
@@ -14,11 +14,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.0 < 5.0.0"
+      "version_requirement": ">= 2.2.0 < 6.0.0"
     },
     {
       "name": "simp-simplib",


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Expanded the upper limit of the concat and stdlib Puppet module versions
- Fixed URLs in the README.md

SIMP-6213 #comment pupmod-simp-tcpwrappers