### PR TITLE
(SIMP-6114) Use namespaced simplib::nets2ddq

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Mar 19 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.2-0
+- Use simplib::nets2ddq in lieu of deprecated Puppet 3 nets2ddq
+
 * Thu Feb 14 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.1-0
 - Use simplib::ipaddresses() in lieu of ipaddresses(), a deprecated
   simplib Puppet 3 function.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-tcpwrappers",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "author": "SIMP Team",
   "summary": "manages /etc/hosts.allow (/etc/hosts.deny is ALL:ALL by default)",
   "license": "Apache-2.0",
@@ -22,7 +22,7 @@
     },
     {
       "name": "simp-simplib",
-      "version_requirement": ">= 3.5.0 < 4.0.0"
+      "version_requirement": ">= 3.8.0 < 4.0.0"
     }
   ],
   "requirements": [

--- a/templates/tcpwrappers.allow.erb
+++ b/templates/tcpwrappers.allow.erb
@@ -6,7 +6,7 @@ Array(@pattern).flatten.each do |ptn|
   if ptn == 'any'
     lpattern.push('ALL')
   elsif ptn !~ /[[:alpha:]]/
-    lpattern.push(scope.function_bracketize([scope.function_nets2ddq([ptn])]))
+    lpattern.push(scope.function_bracketize([scope.call_function('simplib::nets2ddq', [ptn])]))
   else
     lpattern.push(ptn)
   end


### PR DESCRIPTION
Use simplib::nets2ddq in lieu of deprecated Puppet 3 nets2ddq

SIMP-6114 #comment pupmod-simp-tcpwrappers