### PR TITLE
(SIMP-7058) TCP Wrappers deprecated in RHEL 8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Mon Sep 02 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.1.3-0
+- RedHat 8 does not support TCP Wrappers
+- Add call to simplib:assert_metadata to check the OS
+  is supported.
+- Update upperbound of simplib.
+
 * Fri Mar 22 2019 Joseph Sharkey <shark.bruhaha@gmail.com> - 6.1.2-0
 - Use simplib::bracketize in lieu of deprecated Puppet 3 bracketize
 - Fix template bug that prevented some IPv6 addresses from being

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,9 @@ class tcpwrappers (
   String  $package_ensure  = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
 ) {
 
+  # TCP wrappers is not supported in RedHat 8
+  simplib::assert_metadata( $module_name )
+
   package { 'tcp_wrappers':
     ensure => $package_ensure
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-tcpwrappers",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "author": "SIMP Team",
   "summary": "manages /etc/hosts.allow (/etc/hosts.deny is ALL:ALL by default)",
   "license": "Apache-2.0",
@@ -22,7 +22,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.15.0 < 4.0.0"
+      "version_requirement": ">= 3.15.0 < 5.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
- updated module use assert_metadata to check the
  module is being used on a supported os.
- updated upper bound of simplib

SIMP-7058 #close
SIMP-5132 #comment updated TCP Wrappers to check OS.