### PR TITLE
(SIMP-5312) TCP Wrappers Deprecated in RedHat8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Tue Sep 24 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.1.3-0
+- Change metadata OS version check to use new simplib check that returns
+  false or true if the OS is supported according to metadata.json.
+  If it is not supported, do nothing (instead of failing).
+
 * Mon Sep 02 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.1.3-0
 - RedHat 8 does not support TCP Wrappers
 - Add call to simplib:assert_metadata to check the OS

--- a/manifests/allow.pp
+++ b/manifests/allow.pp
@@ -27,9 +27,14 @@ define tcpwrappers::allow (
   Integer                       $order    = 1000,
   Optional[String]              $svc      = undef
 ) {
-  concat::fragment { "tcpwrappers_${name}":
-    order   => $order,
-    target  => '/etc/hosts.allow',
-    content => template("${module_name}/tcpwrappers.allow.erb")
+
+  # Only do something if TCP wrappers is supported.
+
+  if simplib::module_metadata::os_supported(load_module_metadata($module_name)) {
+    concat::fragment { "tcpwrappers_${name}":
+      order   => $order,
+      target  => '/etc/hosts.allow',
+      content => template("${module_name}/tcpwrappers.allow.erb")
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.15.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 5.0.0"
     }
   ],
   "requirements": [

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -34,4 +34,20 @@ describe 'tcpwrappers' do
       end
     end
   end
+  context 'on an unsupported Operating System' do
+    facts = {
+      :os => {
+        'name' => 'Ubuntu',
+        'release' => {
+           'major' => '14',
+           'full'  => '14.999'
+        }
+      }
+    }
+    let(:facts) { facts }
+    it 'should not create resources' do
+          is_expected.to_not  contain_concat('/etc/hosts.allow')
+          is_expected.to_not  contain_package('tcp_wrappers')
+    end
+  end
 end

--- a/spec/defines/allow_spec.rb
+++ b/spec/defines/allow_spec.rb
@@ -2,27 +2,30 @@ require 'spec_helper'
 
 describe 'tcpwrappers::allow' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
+
+        let (:facts) { os_facts }
+
         let(:title) { 'foo_bar' }
         let(:params) { {:pattern => 'localhost'} }
         it { is_expected.to contain_concat__fragment("tcpwrappers_#{title}") }
 
-        context 'with ipv6' do 
+        context 'with ipv6' do
           let(:title) { 'foo_bar' }
           let(:params) { { :pattern => '2001:0db8:85a3:0000:0000:8a2e:0370:7334' } }
           it { is_expected.to contain_concat__fragment("tcpwrappers_#{title}")\
             .with_content(/\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]/) }
         end
 
-        context 'with ipv6 cidr' do 
+        context 'with ipv6 cidr' do
           let(:title) { 'foo_bar' }
           let(:params) { { :pattern => '2001:0db8:85a3:0000:0000:8a2e:0370:7334/64' } }
           it { is_expected.to contain_concat__fragment("tcpwrappers_#{title}")\
             .with_content(/\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]\/64/) }
         end
 
-        context 'with triggered nets2ddq' do 
+        context 'with triggered nets2ddq' do
           let(:title) { 'foo_bar' }
           let(:params) { { :pattern => 'localhost myhost 129.3.0.1 2001:0db8:85a3:0000:0000:8a2e:0370:7334 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64 234.216.15.14/16' } }
           it { is_expected.to contain_concat__fragment("tcpwrappers_#{title}")\
@@ -31,4 +34,23 @@ describe 'tcpwrappers::allow' do
       end
     end
   end
+
+  context 'on an unsupported Operating System' do
+    facts = {
+      :os => {
+        'name' => 'Ubuntu',
+        'release' => {
+           'major' => '14',
+           'full'  => '14.999'
+        }
+      }
+    }
+    let(:facts) { facts }
+    let(:title) { 'foobar' }
+    let(:params) { {:pattern => 'localhost'} }
+    it 'should not create resources' do
+       is_expected.to_not contain_concat__fragment("tcpwrappers_#{title}")
+    end
+  end
+
 end


### PR DESCRIPTION
- update TCP wrappers to use new simplib functions
  to determine if metadata.json indicates support for the OS.
  If it does not, TCP Wrappers will do nothing.
 (Previously, it errored out.)

SIMP-5312 #close
SIMP-7507 #close
SIMP-7060 #close