### PR TITLE
(SIMP-7966) Fix Unit Test Issues

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,7 +4,11 @@ describe 'tcpwrappers' do
   context 'supported operating systems' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let (:facts) { os_facts }
+        let (:facts) {
+          os_facts.merge({
+            :interfaces => 'eth0,lo',
+          })
+        }
 
         it { is_expected.to create_class('tcpwrappers') }
         it { is_expected.to contain_package('tcp_wrappers') }


### PR DESCRIPTION
This changes the unit tests to specify the specific interfaces on the
system in the facts to ensure that the `simplib::ipaddresses` value
returns consistently despite the factsets.

SIMP-7966 #comment sets the interface to resolve dependency on future
  factset gem